### PR TITLE
Undefined name: import os for line 110

### DIFF
--- a/src/scripts/exposure_times/list_exposure_times_from_library.py
+++ b/src/scripts/exposure_times/list_exposure_times_from_library.py
@@ -13,6 +13,7 @@ were at some particular reference magnitude.
 
 import argparse
 import logging
+import os
 from os import path as os_path
 
 from fourgp_fourfs import FourFS

--- a/src/scripts/exposure_times/mean_exposure_time_from_library.py
+++ b/src/scripts/exposure_times/mean_exposure_time_from_library.py
@@ -13,6 +13,7 @@ were at some particular reference magnitude.
 
 import argparse
 import logging
+import os
 from os import path as os_path
 
 import numpy as np


### PR DESCRIPTION
% python3
```
>>> import os.path as os_path
>>> os.uname()
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
NameError: name 'os' is not defined
>>> import os
>>> os.uname()
# Now it works...
```